### PR TITLE
Enable v1.18.0 on Production

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: Jaeger
   sub_title: Tracing
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.14.0"
+  stable_ref: "v1.15.1"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,7 +1,8 @@
  project:
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/color/cncf-color.svg?sanitize=true"
   display_name: Jaeger
-  sub_title: Tracing
+  sub_title: Distributed Tracing
+
   project_url: "https://github.com/jaegertracing/jaeger"
   stable_ref: "v1.14.0"
   head_ref: "master"

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Distributed Tracing
 
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.17.1"
+  stable_ref: "v1.18.0"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Distributed Tracing
 
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.17.0"
+  stable_ref: "v1.17.1"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Distributed Tracing
 
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.15.1"
+  stable_ref: "v1.17.0"
   head_ref: "master"
   ci_system:
     -


### PR DESCRIPTION
## Description

- v1.18.0 was released on 05-18-2020
- update stable on production

## Issues:

https://github.com/vulk/cncf_ci/issues/341

How Has This Been Tested?
---
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested with trigger client against
  - [ ]  cidev.cncf.ci
  - [ ]  dev.cncf.ci
  - [x]  staging.cncf.ci
  - [ ]  cncf.ci (production)
- [ ] Browser tested on staging.cncf.ci
- [ ] Manually tested on https://gitlab.dev.cncf.ci web ui - Build Succeeded
- [ ] Have not tested

Types of changes:
---
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Version update

Checklist:
---
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required