### PR TITLE
Merge jaeger stable v1.18.0 to integration

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: Jaeger
   sub_title: Tracing
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.14.0"
+  stable_ref: "v1.15.1"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,7 +1,8 @@
  project:
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/color/cncf-color.svg?sanitize=true"
   display_name: Jaeger
-  sub_title: Tracing
+  sub_title: Distributed Tracing
+
   project_url: "https://github.com/jaegertracing/jaeger"
   stable_ref: "v1.14.0"
   head_ref: "master"

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Distributed Tracing
 
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.17.1"
+  stable_ref: "v1.18.0"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Distributed Tracing
 
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.17.0"
+  stable_ref: "v1.17.1"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Distributed Tracing
 
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.15.1"
+  stable_ref: "v1.17.0"
   head_ref: "master"
   ci_system:
     -


### PR DESCRIPTION
This was missed as well, but has been pushed through to production. This will update dev.cncf.ci stable to match staging/prod.cncf.ci dashboards.