### PR TITLE
Update jaeger stable v1.19.2 on Prod

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Distributed Tracing
 
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.18.1"
+  stable_ref: "v1.19.2"
   head_ref: "master"
   ci_system:
     -


### PR DESCRIPTION
## Description
  - v1.19.2 was released on 08/27/2020
  - update stable on production; https://gitlab.staging.cncf.ci/jaegertracing/jaeger/-/jobs/199401
  - their travis-ci fails, so it will show failed on our dashboard but should not stop us from updating: https://travis-ci.org/github/jaegertracing/jaeger/builds/721600811

## Issues:

 https://github.com/vulk/cncf_ci/issues/341

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [x]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [x]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
