### PR TITLE
Update Jaeger stable to v1.20.0 on integration (dev.cncf.ci)

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Distributed Tracing
 
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.19.2"
+  stable_ref: "v1.20.0"
   head_ref: "master"
   ci_system:
     -


### PR DESCRIPTION
Passes manual DEV pipeline: https://gitlab.dev.cncf.ci/jaegertracing/jaeger/-/jobs/203689

## Description
  - v1.20.0 was released on 09/29/2020
  - update stable on integration (dev.cncf.ci)

## Issues:

 https://github.com/vulk/cncf_ci/issues/341

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x] Manually Tested on dev.cncf.ci 
 - [ ]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [ ]  dev.cncf.ci
   - [ ]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
