### PR TITLE
Update Stable to v1.21.0 on integration

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -8,8 +8,8 @@
   head_ref: "master"
   ci_system:
     -
-      ci_system_type: "shouldfail"
+      ci_system_type: "travis-ci-com"
       ci_project_url: "https://travis-ci.com/jaegertracing/jaeger"  # can be anything for citest
-      ci_project_name: "shouldfail"
+      ci_project_name: "jaegertracing/jaeger"
       arch:
         - amd64

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -9,7 +9,7 @@
   ci_system:
     -
       ci_system_type: "travis-ci-com"
-      ci_project_url: "https://example.com/jaegertracing/jaeger"  # can be anything for citest
+      ci_project_url: "https://travis-ci.com/jaegertracing/jaeger"  # can be anything for citest
       ci_project_name: "jaegertracing/jaeger"
       arch:
         - amd64

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Distributed Tracing
 
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.20.0"
+  stable_ref: "v1.21.0"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -8,7 +8,7 @@
   head_ref: "master"
   ci_system:
     -
-      ci_system_type: "travis-ci"
+      ci_system_type: "travis-ci-com"
       ci_project_url: "https://example.com/jaegertracing/jaeger"  # can be anything for citest
       ci_project_name: "jaegertracing/jaeger"
       arch:

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -8,8 +8,8 @@
   head_ref: "master"
   ci_system:
     -
-      ci_system_type: "travis-ci-comhi"
+      ci_system_type: "shouldfail"
       ci_project_url: "https://travis-ci.com/jaegertracing/jaeger"  # can be anything for citest
-      ci_project_name: "jaegertracing/jaeger"
+      ci_project_name: "shouldfail"
       arch:
         - amd64

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -8,7 +8,7 @@
   head_ref: "master"
   ci_system:
     -
-      ci_system_type: "travis-ci-com"
+      ci_system_type: "travis-ci-comhi"
       ci_project_url: "https://travis-ci.com/jaegertracing/jaeger"  # can be anything for citest
       ci_project_name: "jaegertracing/jaeger"
       arch:


### PR DESCRIPTION
## Description
 - v1.21.0 was released on 11/16/2020
 - update stable on integration

## Issues:

 https://github.com/vulk/cncf_ci/issues/341

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [ ]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [ ]  dev.cncf.ci
   - [ ]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
