### PR TITLE
Update jaeger stable to v1.21.0 on production

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -8,8 +8,8 @@
   head_ref: "master"
   ci_system:
     -
-      ci_system_type: "shouldfail"
+      ci_system_type: "travis-ci-com"
       ci_project_url: "https://travis-ci.com/jaegertracing/jaeger"  # can be anything for citest
-      ci_project_name: "shouldfail"
+      ci_project_name: "jaegertracing/jaeger"
       arch:
         - amd64

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -9,7 +9,7 @@
   ci_system:
     -
       ci_system_type: "travis-ci-com"
-      ci_project_url: "https://example.com/jaegertracing/jaeger"  # can be anything for citest
+      ci_project_url: "https://travis-ci.com/jaegertracing/jaeger"  # can be anything for citest
       ci_project_name: "jaegertracing/jaeger"
       arch:
         - amd64

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -4,7 +4,7 @@
   sub_title: Distributed Tracing
 
   project_url: "https://github.com/jaegertracing/jaeger"
-  stable_ref: "v1.20.0"
+  stable_ref: "v1.21.0"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -8,7 +8,7 @@
   head_ref: "master"
   ci_system:
     -
-      ci_system_type: "travis-ci"
+      ci_system_type: "travis-ci-com"
       ci_project_url: "https://example.com/jaegertracing/jaeger"  # can be anything for citest
       ci_project_name: "jaegertracing/jaeger"
       arch:

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -8,8 +8,8 @@
   head_ref: "master"
   ci_system:
     -
-      ci_system_type: "travis-ci-comhi"
+      ci_system_type: "shouldfail"
       ci_project_url: "https://travis-ci.com/jaegertracing/jaeger"  # can be anything for citest
-      ci_project_name: "jaegertracing/jaeger"
+      ci_project_name: "shouldfail"
       arch:
         - amd64

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -8,7 +8,7 @@
   head_ref: "master"
   ci_system:
     -
-      ci_system_type: "travis-ci-com"
+      ci_system_type: "travis-ci-comhi"
       ci_project_url: "https://travis-ci.com/jaegertracing/jaeger"  # can be anything for citest
       ci_project_name: "jaegertracing/jaeger"
       arch:


### PR DESCRIPTION
## Description
 - v1.21.0 was released on 11/16/2020
 - update stable on production
 - updates ci_system_type to use travis-ci-com after .org deprecated
 - passes trigger builds: https://gitlab.staging.cncf.ci/jaegertracing/jaeger/-/jobs/201868

## Issues:

 https://github.com/vulk/cncf_ci/issues/341

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x]  Tested with trigger client against
   - [x]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [x]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [x]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
